### PR TITLE
🎈 perf: Assign server context reference to UserServicer during initialization

### DIFF
--- a/src/providers/servicer.py
+++ b/src/providers/servicer.py
@@ -8,4 +8,7 @@ from src.utils.provider import Provider
 class ServicerProvider(Provider):
     @staticmethod
     def register(server: AIOgRPCServer) -> None:
-        server.add_servicer(user_service.add_UserServicer_to_server, UserServicer())
+        server.add_servicer(
+            user_service.add_UserServicer_to_server,
+            UserServicer(server_context_ref=server.context_ref),
+        )


### PR DESCRIPTION
This pull request improves the assignment of the server context reference in the initialization of the UserServicer class. Previously, the server context reference was assigned directly, but now it is assigned through the server_context_ref parameter. This change ensures better code organization and maintainability.