### PR TITLE
🎉 feat: Add GithubOAuthProvider and update some type hints

### DIFF
--- a/src/providers/lifespan.py
+++ b/src/providers/lifespan.py
@@ -1,5 +1,5 @@
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
 
 from src.utils.AIOgRPCServer import AIOgRPCServer, logger
 from src.utils.AIOgRPCServer import Context as AIOgRPCServerContext

--- a/src/providers/oauth.py
+++ b/src/providers/oauth.py
@@ -1,0 +1,34 @@
+import aiohttp
+from api.github.rest.oauth_user import getOAuthUser
+
+from src.api.github.rest.oauth_token import checkOAuthToken, getOAuthToken
+from src.config.github import github_settings
+from src.utils.provider import OAuthProvider
+
+
+class GithubOAuthProvider(OAuthProvider):
+    def __init__(
+        self,
+        client_id: str = github_settings.OAUTH_CLIENT_ID,
+        client_secret: str = github_settings.OAUTH_CLIENT_SECRET.get_secret_value(),
+    ):
+        super().__init__(client_id, client_secret)
+
+    async def get_token(
+        self, code: str, session: aiohttp.ClientSession, redirect_uri: str = ""
+    ):
+        return await getOAuthToken(
+            session,
+            code,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            redirect_uri=redirect_uri,
+        )
+
+    async def get_user_info(self, access_token: str, session: aiohttp.ClientSession):
+        return await getOAuthUser(session, access_token)
+
+    async def check_token(self, access_token: str, session: aiohttp.ClientSession):
+        return await checkOAuthToken(
+            session, access_token, self.client_id, self.client_secret
+        )

--- a/src/providers/servicer.py
+++ b/src/providers/servicer.py
@@ -1,5 +1,6 @@
 from chaserland_grpc_proto.protos.user import user_pb2_grpc as user_service
 
+from src.providers.oauth import GithubOAuthProvider
 from src.servicer.user import UserServicer
 from src.utils.AIOgRPCServer import AIOgRPCServer
 from src.utils.provider import Provider
@@ -8,7 +9,12 @@ from src.utils.provider import Provider
 class ServicerProvider(Provider):
     @staticmethod
     def register(server: AIOgRPCServer) -> None:
+        oauth_providers = [
+            GithubOAuthProvider(),
+        ]
+        servicer = UserServicer(server_context_ref=server.context_ref)
+        servicer.add_oauth_providers(oauth_providers)
         server.add_servicer(
             user_service.add_UserServicer_to_server,
-            UserServicer(server_context_ref=server.context_ref),
+            servicer,
         )


### PR DESCRIPTION
This pull request refactors the OAuthProvider class to use the collections.abc.AsyncIterator instead of typing.AsyncIterator. Additionally, it adds a new class GithubOAuthProvider that provides Github OAuth functionality. The UserServicer in servicer.py is also updated to include the GithubOAuthProvider as an OAuth provider.