### PR TITLE
🐳 chore: Add package inclusion for chaserland_grpc_user_service in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["ChaserZ98 <feiyuzheng98@gmail.com>"]
 readme = "README.md"
+packages = [{ include = "chaserland_grpc_user_service", from = "src" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
This pull request adds the necessary package inclusion for chaserland_grpc_user_service in the pyproject.toml file. This ensures that the package is included when building the project.