### PR TITLE
🦄 refactor: Refactor Context class to use built-in dataclass instead of Pydantic

### DIFF
--- a/src/chaserland_grpc_user_service/core/context.py
+++ b/src/chaserland_grpc_user_service/core/context.py
@@ -1,22 +1,18 @@
+from dataclasses import dataclass
 from typing import Self
 
 import aiohttp
 from chaserland_common.grpc.aio import AbstractContext
-from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from ..db.database import async_session
 
 
-class Context(BaseModel, AbstractContext):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+@dataclass(frozen=True)
+class Context(AbstractContext):
+    http_session: aiohttp.ClientSession = aiohttp.ClientSession()
 
-    http_session: aiohttp.ClientSession = Field(
-        frozen=True, default_factory=aiohttp.ClientSession
-    )
-    db_session: async_sessionmaker[AsyncSession] = Field(
-        frozen=True, default_factory=async_session
-    )
+    db_session: async_sessionmaker[AsyncSession] = async_session
 
     async def __aenter__(self) -> Self:
         return self


### PR DESCRIPTION
This pull request refactors the Context class to use the built-in dataclass module instead of Pydantic. This change simplifies the code and removes the dependency on Pydantic.